### PR TITLE
emacs-git: update

### DIFF
--- a/mingw-w64-emacs-git/PKGBUILD
+++ b/mingw-w64-emacs-git/PKGBUILD
@@ -4,7 +4,7 @@
 _realname='emacs'
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=r126276.66d5c75
+pkgver=r136512.b7730c259b
 pkgrel=1
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 url="https://www.gnu.org/software/${_realname}/"
@@ -12,14 +12,14 @@ license=('GPL3')
 arch=('any')
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-depends=("${MINGW_PACKAGE_PREFIX}-ctags"
+depends=("${MINGW_PACKAGE_PREFIX}-universal-ctags-git"
          "${MINGW_PACKAGE_PREFIX}-xpm-nox"
-         "${MINGW_PACKAGE_PREFIX}-dbus"
          "${MINGW_PACKAGE_PREFIX}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-zlib"
-         "${MINGW_PACKAGE_PREFIX}-imagemagick"
+         "${MINGW_PACKAGE_PREFIX}-harfbuzz"
          "${MINGW_PACKAGE_PREFIX}-winpthreads")
 optdepends=("${MINGW_PACKAGE_PREFIX}-giflib"
+            "${MINGW_PACKAGE_PREFIX}-imagemagick"
             "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
             "${MINGW_PACKAGE_PREFIX}-libpng"
             "${MINGW_PACKAGE_PREFIX}-librsvg"
@@ -27,17 +27,17 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-giflib"
             "${MINGW_PACKAGE_PREFIX}-libxml2")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
+	     "make"
+             "autoconf"
+	     "texinfo"
              "patch"
-             "git")
+             "git"
+	     "${optdepends[@]}")
 # Don't zip info files because the built-in info reader uses gzip to
 # decompress them. gzip is not available as a mingw binary.
 options=('strip' '!zipman')
-source=("${_realname}"::"git+https://git.savannah.gnu.org/git/${_realname}.git"
-        'image.c.diff'
-        'lread.c.diff')
-sha256sums=('SKIP'
-            '4571d45ec26fd556e73a70bb0ab0a2a8fa1efc5e3b3c5b472ab68bb7dc9bf52c'
-            'b9db1b7d939301d0fedf52db6ac055f7265ee5bc0c3c757e394700ca39577b7f')
+source=("${_realname}"::"git+https://git.savannah.gnu.org/git/${_realname}.git")
+sha256sums=('SKIP')
 
 pkgver() {
   cd "${_realname}"
@@ -46,8 +46,6 @@ pkgver() {
 
 prepare() {
   cd "${_realname}"
-  patch --binary --forward -p0 < "${srcdir}/image.c.diff"
-  patch --binary --forward -p0 < "${srcdir}/lread.c.diff"
   ./autogen.sh
 }
 
@@ -59,6 +57,7 @@ build() {
   "${srcdir}/${_realname}/configure" \
     --prefix="${MINGW_PREFIX}" \
     --build="${MINGW_CHOST}" \
+    --without-dbus \
     --with-modules \
     --without-compress-install
 


### PR DESCRIPTION
Removed old patches, they failed to apply and had unknown purpose.

Remove dependency on dbus, emacs does not use it on Windows.

Move most libraries to optdepends, as they are not required to run
emacs.

Use Universal Ctags instead of the unmaintained ctags.

Add dependency on harfbuzz. Emacs uses it by default if present.