### PR TITLE
[WIP] sdcc-svn: Add package

### DIFF
--- a/mingw-w64-sdcc-svn/001-ucsim-comment-out-vsnprintf-prototype.patch
+++ b/mingw-w64-sdcc-svn/001-ucsim-comment-out-vsnprintf-prototype.patch
@@ -1,0 +1,21 @@
+From 3414bbc15d3b1cb31f33272c9c0be00000232875 Mon Sep 17 00:00:00 2001
+From: Tim Stahlhut <stahta01@gmail.com>
+Date: Wed, 26 Aug 2020 04:23:47 -0400
+Subject: Comment out vsnprintf prototype
+
+---
+
+diff --git a/sdcc/sim/ucsim/cmd.src/cmdutil.cc b/sdcc/sim/ucsim/cmd.src/cmdutil.cc
+index 697b4dd45..de72ddbaa 100644
+--- a/sdcc/sim/ucsim/cmd.src/cmdutil.cc
++++ b/sdcc/sim/ucsim/cmd.src/cmdutil.cc
+@@ -107,7 +107,7 @@ proc_escape(char *string, int *len)
+ 
+ 
+ extern "C" int vasprintf(char **strp, const  char *format, va_list ap);
+-extern "C" int vsnprintf(char *str, size_t size,const char *format,va_list ap);
++/* extern "C" int vsnprintf(char *str, size_t size,const char *format,va_list ap); */
+ 
+ int
+ cmd_vfprintf(FILE *f, char *format, va_list ap)
+--

--- a/mingw-w64-sdcc-svn/002-MSys2-MinGW-GCC-Warning-reduction.patch
+++ b/mingw-w64-sdcc-svn/002-MSys2-MinGW-GCC-Warning-reduction.patch
@@ -1,0 +1,38 @@
+From c90365fe65ec9f6a5aba7b880a828e4289d94540 Mon Sep 17 00:00:00 2001
+From: Tim Stahlhut <stahta01@gmail.com>
+Date: Thu, 10 Sep 2020 17:07:49 -0400
+Subject: MSys2 MinGW GCC Warning reduction
+
+This patch helps to prevent segfaults under MSys2 with 
+__USE_MINGW_ANSI_STDIO = 1 and 64 bit build.
+
+This patch is a work around on an MSys2 GCC MinGW issue.
+So, do not try again to push change upstream to the SDCC people.
+Try getting an different GCC patch accepted by the MSys2 packagers and
+then the MinGW64 people.
+---
+ sdcc/support/util/dbuf_string.h | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/sdcc/support/util/dbuf_string.h b/sdcc/support/util/dbuf_string.h
+index 70e9562ed..ba5f77928 100644
+--- a/sdcc/support/util/dbuf_string.h
++++ b/sdcc/support/util/dbuf_string.h
+@@ -41,7 +41,15 @@
+    are accepted by gcc versions 2.6.4 (effectively 2.7) and later.  */
+ #ifndef ATTRIBUTE_PRINTF
+ # if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 7)
+-#  define ATTRIBUTE_PRINTF(m, n) __attribute__ ((__format__ (__printf__, m, n))) ATTRIBUTE_NONNULL(m)
++#   ifndef _WIN32
++#     define ATTRIBUTE_PRINTF(m, n) __attribute__ ((__format__ (__printf__, m, n))) ATTRIBUTE_NONNULL(m)
++#   else
++#     if defined(__USE_MINGW_ANSI_STDIO) && __USE_MINGW_ANSI_STDIO != 0
++#       define ATTRIBUTE_PRINTF(m, n) __attribute__ ((__format__ (__gnu_printf__, m, n))) ATTRIBUTE_NONNULL(m)
++#     else
++#       define ATTRIBUTE_PRINTF(m, n) __attribute__ ((__format__ (__ms_printf__, m, n))) ATTRIBUTE_NONNULL(m)
++#     endif
++#   endif
+ #else
+ #  define ATTRIBUTE_PRINTF(m, n)
+ # endif /* GNUC >= 2.7 */
+-- 

--- a/mingw-w64-sdcc-svn/003-MSys2-sdbinutils-add-USE_MINGW_ANSI_STDIO-guard.patch
+++ b/mingw-w64-sdcc-svn/003-MSys2-sdbinutils-add-USE_MINGW_ANSI_STDIO-guard.patch
@@ -1,0 +1,158 @@
+From 55542daa3e065f930be970c99fb8b7edfb21f321 Mon Sep 17 00:00:00 2001
+From: Tim Stahlhut <stahta01@gmail.com>
+Date: Sun, 4 Oct 2020 13:21:33 -0400
+Subject: sdbinutils: add __USE_MINGW_ANSI_STDIO guard
+
+Helps to prevent Segmentation fault in building 32 bit pdk15-stack-auto/pdk15.lib
+---
+ sdcc/support/sdbinutils/bfd/bfd-in.h       | 2 +-
+ sdcc/support/sdbinutils/bfd/bfd-in2.h      | 2 +-
+ sdcc/support/sdbinutils/bfd/bfd.c          | 2 +-
+ sdcc/support/sdbinutils/binutils/dwarf.c   | 2 +-
+ sdcc/support/sdbinutils/binutils/nm.c      | 4 ++--
+ sdcc/support/sdbinutils/binutils/prdbg.c   | 2 +-
+ sdcc/support/sdbinutils/binutils/readelf.c | 4 ++--
+ sdcc/support/sdbinutils/binutils/strings.c | 6 +++---
+ 8 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/sdcc/support/sdbinutils/bfd/bfd-in.h b/sdcc/support/sdbinutils/bfd/bfd-in.h
+index 2195ce3db..e9cfe44a1 100644
+--- a/sdcc/support/sdbinutils/bfd/bfd-in.h
++++ b/sdcc/support/sdbinutils/bfd/bfd-in.h
+@@ -138,7 +138,7 @@ typedef BFD_HOST_U_64_BIT symvalue;
+ 
+ #if BFD_HOST_64BIT_LONG
+ #define BFD_VMA_FMT "l"
+-#elif defined (__MSVCRT__)
++#elif defined(__MSVCRT__) && (!defined( __USE_MINGW_ANSI_STDIO) || (__USE_MINGW_ANSI_STDIO == 0))
+ #define BFD_VMA_FMT "I64"
+ #else
+ #define BFD_VMA_FMT "ll"
+diff --git a/sdcc/support/sdbinutils/bfd/bfd-in2.h b/sdcc/support/sdbinutils/bfd/bfd-in2.h
+index fb281916b..2bd00d327 100644
+--- a/sdcc/support/sdbinutils/bfd/bfd-in2.h
++++ b/sdcc/support/sdbinutils/bfd/bfd-in2.h
+@@ -145,7 +145,7 @@ typedef BFD_HOST_U_64_BIT symvalue;
+ 
+ #if BFD_HOST_64BIT_LONG
+ #define BFD_VMA_FMT "l"
+-#elif defined (__MSVCRT__)
++#elif defined (__MSVCRT__) && (!defined( __USE_MINGW_ANSI_STDIO) || (__USE_MINGW_ANSI_STDIO == 0))
+ #define BFD_VMA_FMT "I64"
+ #else
+ #define BFD_VMA_FMT "ll"
+diff --git a/sdcc/support/sdbinutils/bfd/bfd.c b/sdcc/support/sdbinutils/bfd/bfd.c
+index 05d475daa..f80b629f4 100644
+--- a/sdcc/support/sdbinutils/bfd/bfd.c
++++ b/sdcc/support/sdbinutils/bfd/bfd.c
+@@ -826,7 +826,7 @@ _bfd_doprnt (FILE *stream, const char *format, union _bfd_doprnt_args *args)
+ 			break;
+ 		      case 2:
+ 		      default:
+-#if defined (__MSVCRT__)
++#if defined (__MSVCRT__) && (!defined( __USE_MINGW_ANSI_STDIO) || (__USE_MINGW_ANSI_STDIO == 0))
+ 			sptr[-3] = 'I';
+ 			sptr[-2] = '6';
+ 			sptr[-1] = '4';
+diff --git a/sdcc/support/sdbinutils/binutils/dwarf.c b/sdcc/support/sdbinutils/binutils/dwarf.c
+index 6dee8aae5..d7996b79e 100644
+--- a/sdcc/support/sdbinutils/binutils/dwarf.c
++++ b/sdcc/support/sdbinutils/binutils/dwarf.c
+@@ -183,7 +183,7 @@ get_encoded_value (unsigned char **pdata,
+ }
+ 
+ #if defined HAVE_LONG_LONG && SIZEOF_LONG_LONG > SIZEOF_LONG
+-# ifndef __MINGW32__
++#if !defined(__MINGW32__) || (defined(__USE_MINGW_ANSI_STDIO) && (__USE_MINGW_ANSI_STDIO == 1))
+ #  define DWARF_VMA_FMT		"ll"
+ #  define DWARF_VMA_FMT_LONG	"%16.16llx"
+ # else
+diff --git a/sdcc/support/sdbinutils/binutils/nm.c b/sdcc/support/sdbinutils/binutils/nm.c
+index e46fffc79..b591a8214 100644
+--- a/sdcc/support/sdbinutils/binutils/nm.c
++++ b/sdcc/support/sdbinutils/binutils/nm.c
+@@ -171,7 +171,7 @@ static char value_format_32bit[] = "%08lx";
+ #if BFD_HOST_64BIT_LONG
+ static char value_format_64bit[] = "%016lx";
+ #elif BFD_HOST_64BIT_LONG_LONG
+-#ifndef __MSVCRT__
++#if !defined(__MSVCRT__) || (defined(__USE_MINGW_ANSI_STDIO) && (__USE_MINGW_ANSI_STDIO == 1))
+ static char value_format_64bit[] = "%016llx";
+ #else
+ static char value_format_64bit[] = "%016I64x";
+@@ -302,7 +302,7 @@ set_print_radix (char *radix)
+ #if BFD_HOST_64BIT_LONG
+       value_format_64bit[5] = *radix;
+ #elif BFD_HOST_64BIT_LONG_LONG
+-#ifndef __MSVCRT__
++#if !defined(__MSVCRT__) || (defined(__USE_MINGW_ANSI_STDIO) && (__USE_MINGW_ANSI_STDIO == 1))
+       value_format_64bit[6] = *radix;
+ #else
+       value_format_64bit[7] = *radix;
+diff --git a/sdcc/support/sdbinutils/binutils/prdbg.c b/sdcc/support/sdbinutils/binutils/prdbg.c
+index 4b9fa06c2..97dce5b2d 100644
+--- a/sdcc/support/sdbinutils/binutils/prdbg.c
++++ b/sdcc/support/sdbinutils/binutils/prdbg.c
+@@ -502,7 +502,7 @@ print_vma (bfd_vma vma, char *buf, bfd_boolean unsignedp, bfd_boolean hexp)
+ #if BFD_HOST_64BIT_LONG_LONG
+   else if (sizeof (vma) <= sizeof (unsigned long long))
+     {
+-#ifndef __MSVCRT__
++#if !defined(__MSVCRT__) || (defined(__USE_MINGW_ANSI_STDIO) && (__USE_MINGW_ANSI_STDIO == 1))
+       if (hexp)
+ 	sprintf (buf, "0x%llx", (unsigned long long) vma);
+       else if (unsignedp)
+diff --git a/sdcc/support/sdbinutils/binutils/readelf.c b/sdcc/support/sdbinutils/binutils/readelf.c
+index ae1cda9a7..9d5e7bc3d 100644
+--- a/sdcc/support/sdbinutils/binutils/readelf.c
++++ b/sdcc/support/sdbinutils/binutils/readelf.c
+@@ -1214,7 +1214,7 @@ dump_relocations (Filedata *          filedata,
+ 		  : "%12.12lx  %12.12lx ",
+ 		  offset, inf);
+ #elif BFD_HOST_64BIT_LONG_LONG
+-#ifndef __MSVCRT__
++#if !defined(__MSVCRT__) || (defined(__USE_MINGW_ANSI_STDIO) && (__USE_MINGW_ANSI_STDIO == 1))
+ 	  printf (do_wide
+ 		  ? "%16.16llx  %16.16llx "
+ 		  : "%12.12llx  %12.12llx ",
+@@ -13255,7 +13255,7 @@ dump_section_as_strings (Elf_Internal_Shdr * section, Filedata * filedata)
+ 	{
+ 	  size_t maxlen = end - data;
+ 
+-#ifndef __MSVCRT__
++#if !defined(__MSVCRT__) || (defined(__USE_MINGW_ANSI_STDIO) && (__USE_MINGW_ANSI_STDIO == 1))
+ 	  /* PR 11128: Use two separate invocations in order to work
+              around bugs in the Solaris 8 implementation of printf.  */
+ 	  printf ("  [%6tx]  ", data - start);
+diff --git a/sdcc/support/sdbinutils/binutils/strings.c b/sdcc/support/sdbinutils/binutils/strings.c
+index da044ac9c..b31be31c8 100644
+--- a/sdcc/support/sdbinutils/binutils/strings.c
++++ b/sdcc/support/sdbinutils/binutils/strings.c
+@@ -557,7 +557,7 @@ print_strings (const char *filename, FILE *stream, file_ptr address,
+ #ifdef HAVE_LONG_LONG
+ 	    if (sizeof (start) > sizeof (long))
+ 	      {
+-# ifndef __MSVCRT__
++#if !defined(__MSVCRT__) || (defined(__USE_MINGW_ANSI_STDIO) && (__USE_MINGW_ANSI_STDIO == 1))
+ 	        printf ("%7llo ", (unsigned long long) start);
+ # else
+ 	        printf ("%7I64o ", (unsigned long long) start);
+@@ -576,7 +576,7 @@ print_strings (const char *filename, FILE *stream, file_ptr address,
+ #ifdef HAVE_LONG_LONG
+ 	    if (sizeof (start) > sizeof (long))
+ 	      {
+-# ifndef __MSVCRT__
++#if !defined(__MSVCRT__) || (defined(__USE_MINGW_ANSI_STDIO) && (__USE_MINGW_ANSI_STDIO == 1))
+ 	        printf ("%7lld ", (unsigned long long) start);
+ # else
+ 	        printf ("%7I64d ", (unsigned long long) start);
+@@ -595,7 +595,7 @@ print_strings (const char *filename, FILE *stream, file_ptr address,
+ #ifdef HAVE_LONG_LONG
+ 	    if (sizeof (start) > sizeof (long))
+ 	      {
+-# ifndef __MSVCRT__
++#if !defined(__MSVCRT__) || (defined(__USE_MINGW_ANSI_STDIO) && (__USE_MINGW_ANSI_STDIO == 1))
+ 	        printf ("%7llx ", (unsigned long long) start);
+ # else
+ 	        printf ("%7I64x ", (unsigned long long) start);
+-- 

--- a/mingw-w64-sdcc-svn/903-Bug-23142-SIGSEGV-in-is_strip_section.patch
+++ b/mingw-w64-sdcc-svn/903-Bug-23142-SIGSEGV-in-is_strip_section.patch
@@ -1,0 +1,36 @@
+From eec523b76adc570f1b7a42b948b3eba03b5594f3 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Mon, 7 May 2018 22:41:47 +0930
+Subject: Bug 23142, SIGSEGV in is_strip_section
+
+	PR 23142
+	* objcopy.c (group_signature): Don't accept groups that use a
+	symbol table other than the one we've read.
+---
+ sdcc/support/sdbinutils/binutils/objcopy.c | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/sdcc/support/sdbinutils/binutils/objcopy.c b/sdcc/support/sdbinutils/binutils/objcopy.c
+index 1e39f6d87..f553c55c2 100644
+--- a/sdcc/support/sdbinutils/binutils/objcopy.c
++++ b/sdcc/support/sdbinutils/binutils/objcopy.c
+@@ -1211,14 +1211,13 @@ group_signature (asection *group)
+     return NULL;
+ 
+   ghdr = &elf_section_data (group)->this_hdr;
+-  if (ghdr->sh_link < elf_numsections (abfd))
++  if (ghdr->sh_link == elf_onesymtab (abfd))
+     {
+       const struct elf_backend_data *bed = get_elf_backend_data (abfd);
+-      Elf_Internal_Shdr *symhdr = elf_elfsections (abfd) [ghdr->sh_link];
++      Elf_Internal_Shdr *symhdr = &elf_symtab_hdr (abfd);
+ 
+-      if (symhdr->sh_type == SHT_SYMTAB
+-	  && ghdr->sh_info > 0
+-	  && ghdr->sh_info < (symhdr->sh_size / bed->s->sizeof_sym))
++      if (ghdr->sh_info > 0
++	  && ghdr->sh_info < symhdr->sh_size / bed->s->sizeof_sym)
+ 	return isympp[ghdr->sh_info - 1];
+     }
+   return NULL;
+-- 

--- a/mingw-w64-sdcc-svn/PKGBUILD
+++ b/mingw-w64-sdcc-svn/PKGBUILD
@@ -67,10 +67,11 @@ prepare() {
 
   cd "$srcdir/${_realname}-svn"
 
+#    002-MSys2-MinGW-GCC-Warning-reduction.patch \
+
   apply_patch_with_msg \
     001-ucsim-comment-out-vsnprintf-prototype.patch \
     903-Bug-23142-SIGSEGV-in-is_strip_section.patch \
-    002-MSys2-MinGW-GCC-Warning-reduction.patch \
     003-MSys2-sdbinutils-add-USE_MINGW_ANSI_STDIO-guard.patch
 }
 

--- a/mingw-w64-sdcc-svn/PKGBUILD
+++ b/mingw-w64-sdcc-svn/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=sdcc
 pkgbase=mingw-w64-${_realname}-svn
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}-svn
-pkgver=4.0.4.r11943
+pkgver=4.0.4.r11951
 pkgrel=1
 pkgdesc="Retargettable ANSI C compiler [Intel 8051, Maxim 80DS390, Zilog Z80 and the Motorola 68HC08] (mingw-w64)"
 arch=('any')

--- a/mingw-w64-sdcc-svn/PKGBUILD
+++ b/mingw-w64-sdcc-svn/PKGBUILD
@@ -1,0 +1,136 @@
+# Contributer: Tim Stahlhut <stahta01@gmail.com>
+
+# Search for "Segmentation fault", "error:", and "Error 127" in all of build, check, package logs
+
+_realname=sdcc
+pkgbase=mingw-w64-${_realname}-svn
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}-svn
+pkgver=4.0.4.r11943
+pkgrel=1
+pkgdesc="Retargettable ANSI C compiler [Intel 8051, Maxim 80DS390, Zilog Z80 and the Motorola 68HC08] (mingw-w64)"
+arch=('any')
+url='https://sourceforge.net/projects/sdcc/'
+license=('GPL') # pic14 and pic16 has non free headers and likely other non free files
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs") # 'boost-libs'
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python")
+# Since latest gputils release is about 4 years old, decided to disable pic14 and pic16 support.
+makedepends=('flex' 'bison' 'diffutils' 'make' 'patch' 'perl' 'svn' 'texinfo' "${MINGW_PACKAGE_PREFIX}-boost") # "${MINGW_PACKAGE_PREFIX}-gputils"
+url="http://sdcc.sourceforge.net/"
+options=('debug' '!strip' 'staticlibs' 'buildflags')
+
+_svntrunk=https://svn.code.sf.net/p/sdcc/code/trunk/sdcc
+
+source=('001-ucsim-comment-out-vsnprintf-prototype.patch' 
+        '903-Bug-23142-SIGSEGV-in-is_strip_section.patch'
+        '002-MSys2-MinGW-GCC-Warning-reduction.patch'
+        '003-MSys2-sdbinutils-add-USE_MINGW_ANSI_STDIO-guard.patch')
+sha256sums=('e2aca7855ad6a0db55e8a4b6f7a6490d12d80ae3aed4e0f254c0e0a5a6fd7abe'
+            'ee4b8da038bc7ecb71fc9f0f129136e6720719093f7faef1a72ee85fa506a618'
+            '6ec485ce3a4547cdd82001cc72704231d92d991af935b655eebd79df9816df5f'
+            'dae365730f708830256a9f64966521bc96bfec565c244f5a5c0492fea3a24185')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp2 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# ======================================= #
+
+prepare() {
+  mkdir -p "$srcdir/svn"
+  msg "Connecting to $_svntrunk SVN server...."
+  if [[ -d ${_realname}-svn/.svn ]]; then
+    msg "Cleanup SVN ...."
+    (cd ${_realname}-svn && svn cleanup)
+    msg "Reverting SVN ...."
+    (cd ${_realname}-svn && svn revert -R .)
+    msg "Updating SVN ...."
+    (cd ${_realname}-svn && svn up --username anonsvn --password anonsvn)
+  else
+    msg "Checking out SVN ...."
+    svn co --username anonsvn --password anonsvn $_svntrunk --config-dir ./svn ${_realname}-svn
+  fi
+
+  cd "$srcdir/${_realname}-svn"
+
+  apply_patch_with_msg \
+    001-ucsim-comment-out-vsnprintf-prototype.patch \
+    903-Bug-23142-SIGSEGV-in-is_strip_section.patch \
+    002-MSys2-MinGW-GCC-Warning-reduction.patch \
+    003-MSys2-sdbinutils-add-USE_MINGW_ANSI_STDIO-guard.patch
+}
+
+pkgver() {
+  cd "$srcdir/${_realname}-svn"
+  local rev="$(svnversion -n | tr -d 'M')"
+  _sdcc_version=$(head -n 1 .version | sed -e 's/.* //' | tr -d '"\n')
+  printf "%s.r%s" "$_sdcc_version" "$rev"
+}
+
+build() {
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+  if [ "${CARCH}" = "x86_64" ]; then
+    LDFLAGS+=""
+  else
+    LDFLAGS+=" -Wl,--large-address-aware"
+  fi
+
+  if check_option "debug" "y"; then
+    local opt_flags=" -Og"
+    opt_flags+=" -ftree-ccp"
+    opt_flags+=" -ftree-bit-ccp"
+    opt_flags+=" -ftree-pta"
+    opt_flags+=" -fif-conversion2"
+    opt_flags+=" -finline-functions-called-once"
+    opt_flags+=" -fcaller-saves"
+    CFLAGS+=${opt_flags}
+    CXXFLAGS+=${opt_flags}
+#  else
+#    CFLAGS+=" -O2"
+#    CXXFLAGS+=" -O2" 
+  fi
+
+  ../${_realname}-svn/configure \
+    CPPLAGS="-D__USE_MINGW_ANSI_STDIO=1" \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --includedir=${MINGW_PREFIX}/include/sdcc \
+    --libdir=${MINGW_PREFIX}/lib/sdcc \
+    --disable-pic14-port \
+    --disable-pic16-port \
+    --disable-werror
+
+  export PATH="${srcdir}/build-${CARCH}/bin:$PATH"
+
+  make --jobs=1
+}
+
+check() {
+  cd "${srcdir}"/build-${CARCH}/support/regression
+  make -k --jobs=1 all || true
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+
+  make install DESTDIR="$pkgdir"
+
+#  # Delete build folder to save space needed when doing check builds
+#  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+}

--- a/mingw-w64-sdcc-svn/PKGBUILD
+++ b/mingw-w64-sdcc-svn/PKGBUILD
@@ -71,8 +71,8 @@ prepare() {
 #    002-MSys2-MinGW-GCC-Warning-reduction.patch \
 
   apply_patch_with_msg \
-    001-ucsim-comment-out-vsnprintf-prototype.patch \
-    003-MSys2-sdbinutils-add-USE_MINGW_ANSI_STDIO-guard.patch
+    001-ucsim-comment-out-vsnprintf-prototype.patch
+#    003-MSys2-sdbinutils-add-USE_MINGW_ANSI_STDIO-guard.patch
 }
 
 pkgver() {

--- a/mingw-w64-sdcc-svn/PKGBUILD
+++ b/mingw-w64-sdcc-svn/PKGBUILD
@@ -67,11 +67,11 @@ prepare() {
 
   cd "$srcdir/${_realname}-svn"
 
+#    903-Bug-23142-SIGSEGV-in-is_strip_section.patch \
 #    002-MSys2-MinGW-GCC-Warning-reduction.patch \
 
   apply_patch_with_msg \
     001-ucsim-comment-out-vsnprintf-prototype.patch \
-    903-Bug-23142-SIGSEGV-in-is_strip_section.patch \
     003-MSys2-sdbinutils-add-USE_MINGW_ANSI_STDIO-guard.patch
 }
 

--- a/mingw-w64-sdcc-svn/PKGBUILD
+++ b/mingw-w64-sdcc-svn/PKGBUILD
@@ -132,6 +132,6 @@ package() {
 
   make install DESTDIR="$pkgdir"
 
-#  # Delete build folder to save space needed when doing check builds
-#  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  # Delete build folder to save space needed when doing check builds
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
 }

--- a/mingw-w64-sdcc-svn/PKGBUILD
+++ b/mingw-w64-sdcc-svn/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=sdcc
 pkgbase=mingw-w64-${_realname}-svn
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}-svn
-pkgver=4.0.4.r11951
+pkgver=4.0.4.r11952
 pkgrel=1
 pkgdesc="Retargettable ANSI C compiler [Intel 8051, Maxim 80DS390, Zilog Z80 and the Motorola 68HC08] (mingw-w64)"
 arch=('any')


### PR DESCRIPTION
Both 64 and 32 bit builds; but, 64 bit has errors during check ( || true used to prevent build from stopping) ; so, 64 bit may have run-time issues. SDCC stands for something like Small Device Compiler. I am hoping this package can help someone to track down the 64 bit test failures. 

Tim S.